### PR TITLE
Ensure listeners are registered only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const callbacks = new Set();
 let called = false;
+let registered = false;
 
 function exit(exit, signal) {
 	if (called) {
@@ -22,7 +23,9 @@ function exit(exit, signal) {
 module.exports = callback => {
 	callbacks.add(callback);
 
-	if (callbacks.size === 1) {
+	if (!registered) {
+		registered = true;
+
 		process.once('exit', exit);
 		process.once('SIGINT', exit.bind(null, true, 2));
 		process.once('SIGTERM', exit.bind(null, true, 15));

--- a/test.js
+++ b/test.js
@@ -1,7 +1,29 @@
 import test from 'ava';
 import execa from 'execa';
+import exitHook from '.';
 
 test('main', async t => {
 	const {stdout} = await execa(process.execPath, ['fixture.js']);
 	t.is(stdout, 'foo\nbar');
+});
+
+test('listener count', t => {
+	t.is(process.listenerCount('exit'), 0);
+
+	const unsubscribe1 = exitHook(() => {});
+	const unsubscribe2 = exitHook(() => {});
+	t.is(process.listenerCount('exit'), 1);
+
+	// Remove all listeners
+	unsubscribe1();
+	unsubscribe2();
+	t.is(process.listenerCount('exit'), 1);
+
+	// Re-add listener
+	const unsubscribe3 = exitHook(() => {});
+	t.is(process.listenerCount('exit'), 1);
+
+	// Remove again
+	unsubscribe3();
+	t.is(process.listenerCount('exit'), 1);
 });


### PR DESCRIPTION
It is possible for the application to re-register the exit-hook listeners many times. This is particularly apparent in unit tests, as they are likely to teardown all the hooks and recreate many times in a row and can cause node to complain about 'Maxeventlisteners exceeded'

Without this fix, the unit test will report that after creating `unsubscribe3` there will be 2 listeners for `exit`. 