### PR TITLE
feat: add support for async hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,14 @@ function exit(exit, signal) {
 
 	isCalled = true;
 
-	for (const callback of callbacks) {
-		callback();
-	}
+	const maybeExit = () => {
+		if (exit === true) {
+			process.exit(128 + signal); // eslint-disable-line unicorn/no-process-exit
+		}
+	};
 
-	if (exit === true) {
-		process.exit(128 + signal); // eslint-disable-line unicorn/no-process-exit
-	}
+	Promise.all(Array.from(callbacks).map(fn => fn())).then(maybeExit); // eslint-disable-line unicorn/prefer-spread
+	setTimeout(maybeExit, 15000).unref();
 }
 
 module.exports = callback => {


### PR DESCRIPTION
I've added support for async hooks.

I've wrapped the callbacks in a `Promise.all`, to end the process as soon as all callbacks complete.

As a backup, I've added a `setTimeout`, to postpone the `exit` by a maximum of 15 seconds. The process will end by whatever happens first. All callbacks resolved, or the 15-sec timeout reached.


```js
// npm i smeijer-forks/exit-hook
import onExit from 'exit-hook';


onExit(async () => {
  // async code here is now supported
  // note that there will be a 15 sec timeout!
});
```    

--- 

resolves #1