### PR TITLE
Fix `gracefulExit()`

### DIFF
--- a/fixture-async.js
+++ b/fixture-async.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import exitHook, {asyncExitHook, gracefulExit} from './index.js';
 
 exitHook(() => {
@@ -28,5 +29,9 @@ asyncExitHook(
 		minimumWait: 200,
 	},
 );
+
+if (process.env.EXIT_HOOK_SYNC === '1') {
+	process.exit(0); // eslint-disable-line unicorn/no-process-exit
+}
 
 gracefulExit();

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ let isCalled = false;
 let isRegistered = false;
 
 async function exit(shouldManuallyExit, isSynchronous, signal) {
+	if (isCalled) {
+		return;
+	}
+
+	isCalled = true;
+
 	if (asyncCallbacks.size > 0 && isSynchronous) {
 		console.error([
 			'SYNCHRONOUS TERMINATION NOTICE:',
@@ -16,12 +22,6 @@ async function exit(shouldManuallyExit, isSynchronous, signal) {
 			'sends a SIGINT to the process running this code.',
 		].join(' '));
 	}
-
-	if (isCalled) {
-		return;
-	}
-
-	isCalled = true;
 
 	const done = (force = false) => {
 		if (force === true || shouldManuallyExit === true) {

--- a/test.js
+++ b/test.js
@@ -4,13 +4,25 @@ import execa from 'execa';
 import exitHook, {asyncExitHook} from './index.js';
 
 test('main', async t => {
-	const {stdout} = await execa(process.execPath, ['fixture.js']);
+	const {stdout, stderr} = await execa(process.execPath, ['fixture.js']);
 	t.is(stdout, 'foo\nbar');
+	t.is(stderr, '');
 });
 
 test('main-async', async t => {
-	const {stdout} = await execa(process.execPath, ['fixture-async.js']);
+	const {stdout, stderr} = await execa(process.execPath, ['fixture-async.js']);
 	t.is(stdout, 'foo\nbar\nquux');
+	t.is(stderr, '');
+});
+
+test('main-async-notice', async t => {
+	const {stdout, stderr} = await execa(process.execPath, ['fixture-async.js'], {
+		env: {
+			EXIT_HOOK_SYNC: '1',
+		},
+	});
+	t.is(stdout, 'foo\nbar');
+	t.regex(stderr, /SYNCHRONOUS TERMINATION NOTICE/);
 });
 
 test('listener count', t => {


### PR DESCRIPTION
This change moves the check for isCalled to the top of the exit() function. Previously, the synchronous check was being checked first, causing a console error when exit() performed the process.exit() at the end of the cleanup window.

Includes changes to fixture-async which allow us to control the type of exit we use when running the fixture, as well as an inclusion of the failure test.

Fixes #21