### PR TITLE
fix: Treats natural node.js process termination as exit code 0

### DIFF
--- a/fixtures/async.js
+++ b/fixtures/async.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import exitHook, {asyncExitHook, gracefulExit} from './index.js';
+import exitHook, {asyncExitHook, gracefulExit} from '../index.js';
 
 exitHook(() => {
 	console.log('foo');

--- a/fixtures/empty.js
+++ b/fixtures/empty.js
@@ -1,0 +1,5 @@
+import exitHook from '../index.js';
+
+exitHook(() => {
+	// https://github.com/sindresorhus/exit-hook/issues/23
+});

--- a/fixtures/sync.js
+++ b/fixtures/sync.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import exitHook from './index.js';
+import exitHook from '../index.js';
 
 exitHook(() => {
 	console.log('foo');

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function addHook(options) {
 		isRegistered = true;
 
 		// Exit cases that support asynchronous handling
-		process.once('beforeExit', exit.bind(undefined, true, false, 0));
+		process.once('beforeExit', exit.bind(undefined, true, false, -128));
 		process.once('SIGINT', exit.bind(undefined, true, false, 2));
 		process.once('SIGTERM', exit.bind(undefined, true, false, 15));
 

--- a/test.js
+++ b/test.js
@@ -4,25 +4,34 @@ import execa from 'execa';
 import exitHook, {asyncExitHook} from './index.js';
 
 test('main', async t => {
-	const {stdout, stderr} = await execa(process.execPath, ['fixture.js']);
+	const {stdout, stderr, exitCode} = await execa(process.execPath, ['./fixtures/sync.js']);
 	t.is(stdout, 'foo\nbar');
 	t.is(stderr, '');
+	t.is(exitCode, 0);
+});
+
+test('main-empty', async t => {
+	const {stderr, exitCode} = await execa(process.execPath, ['./fixtures/empty.js']);
+	t.is(stderr, '');
+	t.is(exitCode, 0);
 });
 
 test('main-async', async t => {
-	const {stdout, stderr} = await execa(process.execPath, ['fixture-async.js']);
+	const {stdout, stderr, exitCode} = await execa(process.execPath, ['./fixtures/async.js']);
 	t.is(stdout, 'foo\nbar\nquux');
 	t.is(stderr, '');
+	t.is(exitCode, 0);
 });
 
 test('main-async-notice', async t => {
-	const {stdout, stderr} = await execa(process.execPath, ['fixture-async.js'], {
+	const {stdout, stderr, exitCode} = await execa(process.execPath, ['./fixtures/async.js'], {
 		env: {
 			EXIT_HOOK_SYNC: '1',
 		},
 	});
 	t.is(stdout, 'foo\nbar');
 	t.regex(stderr, /SYNCHRONOUS TERMINATION NOTICE/);
+	t.is(exitCode, 0);
 });
 
 test('listener count', t => {


### PR DESCRIPTION
# Issue
node.js natural process termination triggered an exit code of `128`, caused by the asynchronous `beforeExit` event.

# Fix
Changes the asynchronous `beforeExit` to trigger with an exit code 0, mirroring the behavior used the PM2 event

# Summary of Changes - patch level change

* Moved fixtures to a `/fixtures` directory (when you create the third fixture, you'll probably need the 4th down the line and this makes it clear where they go)
* Added `empty` fixture that replicates the bug reported in 23
* Resolves issue in `index.js`

Fixes #23