### PR TITLE
[breaking] feat: Moves `minimumWait` to `wait` and updates to LTS only

### DIFF
--- a/fixtures/async.js
+++ b/fixtures/async.js
@@ -26,7 +26,7 @@ asyncExitHook(
 		console.log('quux');
 	},
 	{
-		minimumWait: 200,
+		wait: 200,
 	},
 );
 

--- a/fixtures/signal.js
+++ b/fixtures/signal.js
@@ -7,7 +7,7 @@ exitHook(signal => {
 asyncExitHook(async signal => {
 	console.log(signal);
 }, {
-	minimumWait: 200,
+	wait: 200,
 });
 
 setInterval(() => {}, 1 << 30);

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ import {asyncExitHook} from 'exit-hook';
 asyncExitHook(() => {
 	console.log('Exiting');
 }, {
-	minimumWait: 500
+	wait: 500
 });
 
 throw new Error('🦄');
@@ -61,7 +61,7 @@ throw new Error('🦄');
 //=> 'Exiting'
 
 // Removing an exit hook:
-const unsubscribe = asyncExitHook(() => {}, {minimumWait: 500});
+const unsubscribe = asyncExitHook(() => {}, {wait: 500});
 
 unsubscribe();
 ```
@@ -83,7 +83,7 @@ import {asyncExitHook, gracefulExit} from 'exit-hook';
 asyncExitHook(() => {
 	console.log('Exiting');
 }, {
-	minimumWait: 500
+	wait: 500
 });
 
 // Instead of `process.exit()`
@@ -94,7 +94,7 @@ export function gracefulExit(signal?: number): void;
 
 export interface Options {
 	/**
-	The amount of time in milliseconds that the `onExit` function is expected to take.
+	The amount of time in milliseconds that the `onExit` function is expected to take. When multiple async handlers are registered, the longest `wait` time will be used.
 	*/
-	minimumWait: number;
+	wait: number;
 }

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ async function exit(shouldManuallyExit, isSynchronous, signal) {
 }
 
 function addHook(options) {
-	const {onExit, minimumWait, isSynchronous} = options;
-	const asyncCallbackConfig = [onExit, minimumWait];
+	const {onExit, wait, isSynchronous} = options;
+	const asyncCallbackConfig = [onExit, wait];
 
 	if (isSynchronous) {
 		callbacks.add(onExit);
@@ -116,13 +116,13 @@ export function asyncExitHook(onExit, options = {}) {
 		throw new TypeError('onExit must be a function');
 	}
 
-	if (!(typeof options.minimumWait === 'number' && options.minimumWait > 0)) {
-		throw new TypeError('minimumWait must be set to a positive numeric value');
+	if (!(typeof options.wait === 'number' && options.wait > 0)) {
+		throw new TypeError('wait must be set to a positive numeric value');
 	}
 
 	return addHook({
 		onExit,
-		minimumWait: options.minimumWait,
+		wait: options.wait,
 		isSynchronous: false,
 	});
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@ import exitHook, {asyncExitHook} from './index.js';
 const unsubscribe = exitHook(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
 const asyncUnsubscribe = asyncExitHook(async () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
-	{minimumWait: 300},
+	{wait: 300},
 );
 
 expectType<() => void>(unsubscribe);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": ">=18.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/readme.md
+++ b/readme.md
@@ -74,11 +74,11 @@ The callback function to execute when the process exits via `gracefulExit`, and 
 
 Type: `object`
 
-##### minimumWait
+##### wait
 
 Type: `number`
 
-The amount of time in milliseconds that the `onExit` function is expected to take.
+The amount of time in milliseconds that the `onExit` function is expected to take. When multiple async handlers are registered, the longest `wait` time will be used.
 
 ```js
 import {asyncExitHook} from 'exit-hook';
@@ -86,7 +86,7 @@ import {asyncExitHook} from 'exit-hook';
 asyncExitHook(async () => {
 	console.log('Exiting');
 }, {
-	minimumWait: 300
+	wait: 300
 });
 
 throw new Error('🦄');
@@ -102,7 +102,7 @@ import {asyncExitHook} from 'exit-hook';
 const unsubscribe = asyncExitHook(async () => {
 	console.log('Exiting');
 }, {
-	minimumWait: 300
+	wait: 300
 });
 
 unsubscribe();
@@ -135,4 +135,4 @@ Node.js does not offer an asynchronous shutdown API by default [#1](https://gith
 
 If you have asynchronous hooks registered and your Node.js process is terminated in a synchronous manner, a `SYNCHRONOUS TERMINATION NOTICE` error will be logged to the console. To avoid this, ensure you're only exiting via `gracefulExit` or that an upstream process manager is sending a `SIGINT` or `SIGTERM` signal to Node.js.
 
-Asynchronous hooks should make a "best effort" to perform their tasks within the `minimumWait` time, but also be written to assume they may not complete their tasks before termination.
+Asynchronous hooks should make a "best effort" to perform their tasks within the `wait` time, but also be written to assume they may not complete their tasks before termination.

--- a/test.js
+++ b/test.js
@@ -58,7 +58,7 @@ test('listener count', t => {
 	const unsubscribe4 = asyncExitHook(
 		async () => {},
 		{
-			minimumWait: 100,
+			wait: 100,
 		},
 	);
 	t.is(process.listenerCount('exit'), 1);
@@ -77,13 +77,18 @@ test('type enforcing', t => {
 	// Non-function passed to `asyncExitHook`.
 	t.throws(() => {
 		asyncExitHook(null, {
-			minimumWait: 100,
+			wait: 100,
 		});
 	}, {
 		instanceOf: TypeError,
 	});
 
-	// Non-numeric passed to `minimumWait` option.
+	// Non-numeric passed to `wait` option.
+	t.throws(() => {
+		asyncExitHook(async () => true, {wait: 'abc'});
+	});
+
+	// Empty value passed to `wait` option.
 	t.throws(() => {
 		asyncExitHook(async () => true, {});
 	});


### PR DESCRIPTION
There's been ongoing discussion in the original PR and in #32 about naming the "wait" value. At registration time, it's the minimum amount of time a function waits, but at `gracefulExit`, it's the largest minimum wait value. To eliminate this confusion, the option was renamed to "wait" and the documentation was updated to reflect this.

Because this is a breaking change, we're also co-introducing the LTS changes. It can be split off into a separate PR if desired, but it did not add substantial complexity to this PR.

BREAKING CHANGES (forces major bump):
* `minimumWait` is now `wait`
* Package requires Node 18+ (currently supported LTS)